### PR TITLE
Validate blank sort grant directories

### DIFF
--- a/tasks/sort/environment.go
+++ b/tasks/sort/environment.go
@@ -13,6 +13,7 @@ const (
 	sortGrantDownloadsDirectoryKey                  = "grant.base_directories.downloads"
 	sortGrantStagingDirectoryKey                    = "grant.base_directories.staging"
 	sortGrantDirectoryMissingEnvironmentErrorFormat = "resolve %s: missing environment variable(s): %s"
+	sortGrantDirectoryBlankErrorFormat              = "resolve %s: expanded value is blank"
 )
 
 type environmentLookupFunc func(string) (string, bool)
@@ -38,6 +39,9 @@ func resolveSortGrantDirectory(rawValue string, configurationKey string, lookup 
 	expandedValue, missingVariables := expandEnvironmentVariables(rawValue, lookup)
 	if len(missingVariables) > 0 {
 		return "", fmt.Errorf(sortGrantDirectoryMissingEnvironmentErrorFormat, configurationKey, strings.Join(missingVariables, ", "))
+	}
+	if strings.TrimSpace(expandedValue) == "" {
+		return "", fmt.Errorf(sortGrantDirectoryBlankErrorFormat, configurationKey)
 	}
 	return expandedValue, nil
 }

--- a/tasks/sort/environment_test.go
+++ b/tasks/sort/environment_test.go
@@ -64,6 +64,30 @@ func TestResolveSortGrantBaseDirectories(t *testing.T) {
 				return sortConfiguration
 			}(),
 		},
+		{
+			name: "returns error when downloads directory literal is blank",
+			source: func() config.Sort {
+				var sortConfiguration config.Sort
+				sortConfiguration.Grant.BaseDirectories.Downloads = "   "
+				sortConfiguration.Grant.BaseDirectories.Staging = "/opt/staging"
+				return sortConfiguration
+			}(),
+			environmentValues:   map[string]string{},
+			expectedErrorSubstr: sortGrantDownloadsDirectoryKey,
+		},
+		{
+			name: "returns error when downloads directory expansion is blank",
+			source: func() config.Sort {
+				var sortConfiguration config.Sort
+				sortConfiguration.Grant.BaseDirectories.Downloads = "${EMPTY_DOWNLOADS_DIR}"
+				sortConfiguration.Grant.BaseDirectories.Staging = "/opt/staging"
+				return sortConfiguration
+			}(),
+			environmentValues: map[string]string{
+				"EMPTY_DOWNLOADS_DIR": "  ",
+			},
+			expectedErrorSubstr: sortGrantDownloadsDirectoryKey,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
## Summary
- add validation to fail when resolved sort grant directories are blank
- ensure new validation is exercised through blank literal and expansion tests

## Testing
- go test ./tasks/sort

------
https://chatgpt.com/codex/tasks/task_e_68db153a1434832783c646e70b0beaa1